### PR TITLE
Keeps the deploy stage from running on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
     # other than the default one are not available in Travis’s checkout.
     script: yarn run test:since $TRAVIS_PULL_REQUEST_SHA^1
   - stage: deploy
-    if: branch =~ ^production-
+    if: branch =~ ^production- AND type IN (push)
     install: skip
     script: skip
     before_deploy:


### PR DESCRIPTION
Travis would stop it from deploying, but might as well keep it from
running in the first place for speed.