### PR TITLE
Tweaks to Travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 - npm install -g yarn@`jq -r .engines.yarn package.json`
 jobs:
   include:
-  - if: type IN (push)
+  - if: type IN (push) AND NOT (branch =~ ^staging\/)
     script: yarn run test
   - if: type IN (pull_request)
     # TRAVIS_PULL_REQUEST_SHA is the SHA of the PR’s merge commit. Getting ^1 is
@@ -27,6 +27,8 @@ jobs:
     script: skip
     deploy:
       provider: script
+      # We need the node_modules installed to run our deploy binary
+      skip_cleanup: true
       script: deploy/travis-deploy.sh
       on:
         # Stage’s "if" limits to the branches we want, so let everything


### PR DESCRIPTION
 - Doesn't run tests on staging pushes
 - Keeps node_modules around so deploy script can run