### PR TITLE
Compilation and reliability fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,9 @@ TypeScript files.
 These are libraries of React components. We want to use Babel to build these
 libraries to take advantage of the frontend-specific Babel plugins (such as
 `@babel/env`, `emotion`, _&c._). They should output browser-compatible (ES5)
-code, but with ES2015 modules for Webpack, referenced by the `"module"` value in
-their `package.json` files. They should also have a `"main"` that points to the
-same file as `"module"` so that it can be resolved when running `jest`. (`jest`
-+ `babel-jest` seem to be able to handle the `import`/`export` statements in
-these files, they just don’t understand `"module"`.)
+code. Their `"main"` file should be a CommonJS bundle built with Rollup. There
+should also be a `"module"` entry with ES2015 module syntax (`import`/`export`)
+for better Webpack unused code removal.
 
 These packages should load the `@cityofboston/config-babel/react` preset from
 their `.babelrc` files, which uses `@babel/env` to generate browser-compatible

--- a/modules-js/react-fleet/package.json
+++ b/modules-js/react-fleet/package.json
@@ -4,15 +4,15 @@
   "description": "Components for using Fleet in our webapps",
   "private": true,
   "license": "CC0-1.0",
+  "main": "build/react-fleet.es5.js",
   "module": "build/react-fleet.js",
-  "main": "build/react-fleet.js",
   "types": "build/react-fleet.d.ts",
   "sideEffects": false,
   "scripts": {
-    "watch": "npm run build:babel -- --watch",
+    "watch": "concurrently \"npm run build:babel -- --watch\" \"rollup -c -w\"",
     "storybook": "start-storybook -p 9001",
     "prebuild": "rimraf build",
-    "build": "concurrently \"npm run build:typescript\" \"npm run build:babel\"",
+    "build": "concurrently \"npm run build:typescript\" \"npm run build:babel && rollup -c\"",
     "build:typescript": "tsc --emitDeclarationOnly",
     "build:babel": "cross-env BABEL_ENV=esm babel src --ignore '**/*.stories.*','**/*.test.*' --out-dir build --extensions \".ts,.tsx\"",
     "prepare": "npm run build",
@@ -62,6 +62,7 @@
     "node-fetch": "^1.6.9",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.6.2",
+    "rollup": "^0.60.1",
     "ts-node": "^6.0.3",
     "typescript": "^2.8.1"
   }

--- a/modules-js/react-fleet/rollup.config.js
+++ b/modules-js/react-fleet/rollup.config.js
@@ -1,0 +1,11 @@
+const EXTERNALS = ['react'];
+
+export default {
+  input: 'build/react-fleet.js',
+  output: {
+    file: 'build/react-fleet.es5.js',
+    format: 'cjs',
+  },
+  // Regexp form so we can wildcard
+  external: id => /^@babel\/runtime\//.test(id) || EXTERNALS.includes(id),
+};

--- a/package.json
+++ b/package.json
@@ -34,9 +34,6 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --quiet"
   },
-  "resolutions": {
-    "graphql": "0.13.2"
-  },
   "devDependencies": {
     "@yarnpkg/lockfile": "^1.0.0",
     "eslint": "^4.19.1",

--- a/services-js/commissions-app/package.json
+++ b/services-js/commissions-app/package.json
@@ -73,7 +73,7 @@
     "@types/storybook__addon-storyshots": "^3.4.1",
     "@types/storybook__react": "^3.0.7",
     "@zeit/next-typescript": "^1.0.0",
-    "apollo-codegen": "^0.19.1",
+    "apollo-codegen": "CityOfBoston/apollo-codegen#dist",
     "babel-core": "^7.0.0-0",
     "concurrently": "^3.5.1",
     "eslint-plugin-graphql": "^2.1.1",

--- a/services-js/commissions-app/tsconfig.server.json
+++ b/services-js/commissions-app/tsconfig.server.json
@@ -10,6 +10,7 @@
   ],
   "exclude": [
     "src/client/**/*",
-    "src/pages/**/*"
+    "src/pages/**/*",
+    "src/stories/**/*"
   ]
 }

--- a/templates/js-browser-module/template/package.json
+++ b/templates/js-browser-module/template/package.json
@@ -4,14 +4,14 @@
   "description": "{{description}}",
   "private": true,
   "license": "CC0-1.0",
-  "main": "build/{{name}}.js",
+  "main": "build/{{name}}.es5.js",
   "module": "build/{{name}}.js",
   "types": "build/{{name}}.d.ts",
   "sideEffects": false,
   "scripts": {
-    "watch": "npm run build:babel -- --watch",
+    "watch": "concurrently \"npm run build:babel -- --watch\" \"rollup -c -w\"",
     "prebuild": "rimraf build",
-    "build": "concurrently \"npm run build:typescript\" \"npm run build:babel\"",
+    "build": "concurrently \"npm run build:typescript\" \"npm run build:babel && rollup -c\"",
     "build:typescript": "tsc --emitDeclarationOnly",
     "build:babel": "cross-env BABEL_ENV=esm babel src --out-dir build --extensions \".ts,.tsx\"",
     "prepare": "npm run build",
@@ -37,6 +37,7 @@
     "cross-env": "^5.1.5",
     "jest": "^22.4.0",
     "rimraf": "^2.6.2",
+    "rollup": "^0.60.1",
     "typescript": "^2.8.1"
   }
 }

--- a/templates/js-browser-module/template/rollup.config.js
+++ b/templates/js-browser-module/template/rollup.config.js
@@ -1,0 +1,11 @@
+const EXTERNALS = ['react'];
+
+export default {
+  input: 'build/{{name}}.js',
+  output: {
+    file: 'build/{{name}}.es5.js',
+    format: 'cjs',
+  },
+  // Regexp form so we can wildcard
+  external: id => /^@babel\/runtime\//.test(id) || EXTERNALS.includes(id),
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1540,6 +1540,10 @@
   version "0.22.7"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.7.tgz#4a92eafedfb2b9f4437d3a4410006d81114c66ce"
 
+"@types/estree@0.0.39":
+  version "0.0.39"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
+
 "@types/events@*":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
@@ -2069,9 +2073,9 @@ apollo-cache-control@^0.1.0:
   dependencies:
     graphql-extensions "^0.0.x"
 
-apollo-codegen@^0.19.1:
+apollo-codegen@CityOfBoston/apollo-codegen#dist:
   version "0.19.1"
-  resolved "https://registry.yarnpkg.com/apollo-codegen/-/apollo-codegen-0.19.1.tgz#30444de019f453c0d6ec167072b8e11b52d7f92e"
+  resolved "https://codeload.github.com/CityOfBoston/apollo-codegen/tar.gz/4d17e82f48dc09fc5c1089bd0848e5f51c7df86a"
   dependencies:
     "@babel/generator" "7.0.0-beta.38"
     "@babel/types" "7.0.0-beta.38"
@@ -2080,7 +2084,7 @@ apollo-codegen@^0.19.1:
     core-js "^2.5.3"
     glob "^7.1.2"
     graphql "^0.13.1"
-    graphql-config "^1.1.1"
+    graphql-config "^2.0.1"
     inflected "^2.0.3"
     node-fetch "^1.7.3"
     rimraf "^2.6.2"
@@ -6484,17 +6488,6 @@ graceful-fs@~3.0.2:
   dependencies:
     natives "^1.1.0"
 
-graphql-config@^1.1.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-1.2.1.tgz#97b4403707db408feb335fbc159651f2a36cb558"
-  dependencies:
-    graphql "^0.12.3"
-    graphql-import "^0.4.0"
-    graphql-request "^1.4.0"
-    js-yaml "^3.10.0"
-    lodash "^4.17.4"
-    minimatch "^3.0.4"
-
 graphql-config@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-2.0.1.tgz#d34a9bdf1d7360af7b01db9b20260a342ddc7390"
@@ -6512,13 +6505,13 @@ graphql-extensions@^0.0.x, graphql-extensions@~0.0.9:
     core-js "^2.5.3"
     source-map-support "^0.5.1"
 
-graphql-import@^0.4.0, graphql-import@^0.4.4:
+graphql-import@^0.4.4:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/graphql-import/-/graphql-import-0.4.5.tgz#e2f18c28d335733f46df8e0733d8deb1c6e2a645"
   dependencies:
     lodash "^4.17.4"
 
-graphql-request@^1.4.0, graphql-request@^1.5.0:
+graphql-request@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.6.0.tgz#afe87cf2a336acabb0cc2a875900202eda89f412"
   dependencies:
@@ -6534,7 +6527,7 @@ graphql-tools@^3.0.0:
     iterall "^1.1.3"
     uuid "^3.1.0"
 
-graphql@0.13.2, graphql@^0.12.3, graphql@^0.13.1, graphql@^0.13.2:
+graphql@^0.13.1, graphql@^0.13.2:
   version "0.13.2"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.13.2.tgz#4c740ae3c222823e7004096f832e7b93b2108270"
   dependencies:
@@ -11426,6 +11419,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+rollup@^0.60.1:
+  version "0.60.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.60.1.tgz#07cb66153f1541d5f7e82b8393b405c31647dae9"
+  dependencies:
+    "@types/estree" "0.0.39"
+    "@types/node" "*"
 
 run-async@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
 - Switches to use Rollup to generate a CommonJS bundle for UI
   libraries so that they can be resolved when using Jest. (The previous
   plan of just pointing "main" at an ES2015 module made Webpack think
   it should treat that file as CommonJS instead of ES2015.)
 - Switches to a custom build of apollo-codegen that uses the same
   version of graphql as other libraries. Removes the need to force a
   module resolution, which is fragile when using workspaces (it was
   only respected when running yarn commands from the repo root).
 - Excludes "stories" from the tsconfig.server.json file to prevent
   tsc-watch from reloading due to Next compilation.