### PR TITLE
Changes Commission.authority to be nullable

### DIFF
--- a/.graphqlconfig
+++ b/.graphqlconfig
@@ -1,0 +1,10 @@
+{
+  "projects": {
+    "commissions-app": {
+      "schemaPath": "./services-js/commissions-app/graphql/schema.graphql",
+      "includes": [
+        "./services-js/commissions-app/**/*.{graphql,ts,tsx,js,jsx}"
+      ]
+    }
+  }
+}

--- a/services-js/commissions-app/.eslintrc
+++ b/services-js/commissions-app/.eslintrc
@@ -3,7 +3,17 @@
     "graphql"
   ],
   "rules": {
-    "graphql/template-strings": "error",
-    "graphql/named-operations": "error"
+    "graphql/template-strings": [
+      "error",
+      {
+        "projectName": "commissions-app"
+      }
+    ],
+    "graphql/named-operations": [
+      "error",
+      {
+        "projectName": "commissions-app"
+      }
+    ]
   }
 }

--- a/services-js/commissions-app/.graphqlconfig
+++ b/services-js/commissions-app/.graphqlconfig
@@ -1,3 +1,0 @@
-{
-  "schemaPath": "graphql/schema.graphql"
-}

--- a/services-js/commissions-app/package.json
+++ b/services-js/commissions-app/package.json
@@ -17,7 +17,7 @@
     "pretest": "tsc --noEmit",
     "test": "scripts/test.js",
     "generate-graphql-schema": "mkdir -p graphql && ts2gql src/server/graphql/schema.ts > graphql/schema.graphql",
-    "generate-graphql-types": "apollo-codegen generate src/client/**/*.ts --target typescript --output src/client/graphql/queries.d.ts && prettier --write src/client/graphql/queries.d.ts",
+    "generate-graphql-types": "apollo-codegen generate src/client/**/*.ts --project-name commissions-app --target typescript --output src/client/graphql/queries.d.ts && prettier --write src/client/graphql/queries.d.ts",
     "generate-fixtures": "ts-node ./scripts/generate-fixtures.ts",
     "travis-deploy": "travis-js-service-deploy deploy/Dockerfile"
   },

--- a/services-js/commissions-app/src/server/graphql/schema.test.ts
+++ b/services-js/commissions-app/src/server/graphql/schema.test.ts
@@ -1,0 +1,71 @@
+import { commissionResolvers } from './schema';
+import CommissionsDao, { DbBoard, DbAuthority } from '../dao/CommissionsDao';
+
+jest.mock('../dao/CommissionsDao');
+
+const STATE_AUTHORITY: DbAuthority = {
+  AuthorityId: 4,
+  AuthorityType: 'State',
+  AddBy: '',
+  AddDtTm: new Date(),
+  ModBy: '',
+  ModDtTm: new Date(),
+};
+
+const NOT_APPLICABLE_AUTHORITY: DbAuthority = {
+  AuthorityId: 4,
+  AuthorityType: 'Not applicable',
+  AddBy: '',
+  AddDtTm: new Date(),
+  ModBy: '',
+  ModDtTm: new Date(),
+};
+
+beforeEach(() => {
+  const MockCommissionsDao = CommissionsDao as jest.Mock<CommissionsDao>;
+  MockCommissionsDao.mockClear();
+});
+
+describe('Commission resolvers', () => {
+  describe('authority', () => {
+    let board: DbBoard;
+    let commissionsDao: jest.Mocked<CommissionsDao>;
+
+    beforeEach(() => {
+      board = {} as any;
+      commissionsDao = new CommissionsDao(null as any) as any;
+    });
+
+    it('handles when the authority ID is null', async () => {
+      board.AuthorityId = null;
+
+      expect(
+        await commissionResolvers.authority(board, {}, { commissionsDao }, {})
+      ).toEqual(null);
+    });
+
+    it('returns the authority name', async () => {
+      board.AuthorityId = 4;
+
+      commissionsDao.fetchAuthority.mockReturnValue(
+        Promise.resolve(STATE_AUTHORITY)
+      );
+
+      expect(
+        await commissionResolvers.authority(board, {}, { commissionsDao }, {})
+      ).toEqual('State');
+    });
+
+    it('turns a “Not Applicable” authority into null', async () => {
+      board.AuthorityId = 4;
+
+      commissionsDao.fetchAuthority.mockReturnValue(
+        Promise.resolve(NOT_APPLICABLE_AUTHORITY)
+      );
+
+      expect(
+        await commissionResolvers.authority(board, {}, { commissionsDao }, {})
+      ).toEqual(null);
+    });
+  });
+});


### PR DESCRIPTION
Makes "Not applicable" authorities null and adds test coverage.

Also moves .graphqlconfig up to the root level to better-support GraphQL
plugins for text editors.