### PR TITLE
Adds CORS headers for /graphql endpoint

### DIFF
--- a/services-js/commissions-app/src/server/commissions-app.ts
+++ b/services-js/commissions-app/src/server/commissions-app.ts
@@ -167,7 +167,13 @@ export async function makeServer(port) {
     plugin: graphqlHapi,
     options: {
       path: `${PATH_PREFIX}/graphql`,
-      auth: 'apiHeaderKeys',
+      route: {
+        auth: 'apiHeaderKeys',
+        cors: {
+          origin: ['localhost', '*.boston.gov'],
+          additionalHeaders: ['X-API-KEY'],
+        },
+      },
       graphqlOptions: () => ({
         schema: graphqlSchema,
         context: {


### PR DESCRIPTION
Also fixes auth option, which should be in the "route" key of the plugin
registration.