### PR TITLE
Allows policyTypeIds to be null

### DIFF
--- a/services-js/commissions-app/src/server/graphql/schema.ts
+++ b/services-js/commissions-app/src/server/graphql/schema.ts
@@ -105,7 +105,7 @@ const queryRootResolvers: Resolvers<Query, Context> = {
 
     // typeof checks because all of the args are optional
 
-    if (typeof policyTypeIds !== 'undefined') {
+    if (Array.isArray(policyTypeIds)) {
       commissions = commissions.filter(
         ({ PolicyTypeId }) =>
           typeof PolicyTypeId === 'number' &&


### PR DESCRIPTION
Previously we were looking specifically for undefined, so a null would
fall through and fail at the includes call.