### PR TITLE
Makes SQL tolerant of boards with no one active

### DIFF
--- a/services-js/commissions-app/src/server/dao/CommissionsDao.ts
+++ b/services-js/commissions-app/src/server/dao/CommissionsDao.ts
@@ -10,8 +10,9 @@ import {
 } from './CommissionsDb.d';
 
 export type DbBoard = BoardsEntityAll & {
-  // Added by the BQARD_SQL below
-  ActiveCount: number;
+  /** Added by the BOARD_SQL below. Can be null if there are no active members
+   * to 'COUNT' */
+  ActiveCount: number | null;
 };
 export type DbDepartment = DepartmentsEntityAll;
 export type DbAuthority = AuthorityTypesEntityAll;
@@ -25,9 +26,11 @@ export type DbPolicyType = PolicyTypesEntityAll;
  *
  * We do this with a join for efficiency rather than pulling in all of the
  * members and doing a JS-side filter.
+ *
+ * LEFT JOIN so that we get boards even with no active members.
  */
 const BOARD_SQL = `
-  SELECT * FROM dbo.Boards JOIN
+  SELECT * FROM dbo.Boards LEFT JOIN
     (SELECT Assignments.BoardId, COUNT(Assignments.PersonId) as ActiveCount
       FROM Assignments
       WHERE Assignments.StatusId = 101

--- a/services-js/commissions-app/src/server/graphql/schema.ts
+++ b/services-js/commissions-app/src/server/graphql/schema.ts
@@ -123,7 +123,7 @@ const queryRootResolvers: Resolvers<Query, Context> = {
 
     if (typeof hasOpenSeats === 'boolean') {
       commissions = commissions.filter(
-        ({ ActiveCount, Seats }) => ActiveCount < Seats === hasOpenSeats
+        ({ ActiveCount, Seats }) => (ActiveCount || 0) < Seats === hasOpenSeats
       );
     }
 
@@ -173,8 +173,9 @@ export const commissionResolvers: Resolvers<Commission, Context> = {
   seats: ({ Seats }) => Seats,
   enablingLegislation: ({ Legislation }) => Legislation,
   // Currently some boards have "0" for the number of seats, so the open seat
-  // calculation ends up negative.
-  openSeats: ({ ActiveCount, Seats }) => Math.max(0, Seats - ActiveCount),
+  // calculation ends up negative. `max 0` keeps us from looking silly.
+  openSeats: ({ ActiveCount, Seats }) =>
+    Math.max(0, Seats - (ActiveCount || 0)),
   applyUrl: ({ BoardName }) =>
     `https://www.cityofboston.gov/boardsandcommissions/application/apply.aspx?bid=${encodeURIComponent(
       BoardName!


### PR DESCRIPTION
Changes to a LEFT JOIN that will always return the Board rows,
regardless of whether there's anything in Assignments for that BoardID.