### PR TITLE
Adds apps support to Access Boston

### DIFF
--- a/scripts/generate-ssl-key.sh
+++ b/scripts/generate-ssl-key.sh
@@ -10,6 +10,6 @@ openssl genrsa -des3 -passout pass:x -out "${FILENAME_BASE}.pass.key" 2048
 openssl rsa -passin pass:x -in "${FILENAME_BASE}.pass.key" -out "${FILENAME_BASE}.key"
 rm "${FILENAME_BASE}.pass.key"
 openssl req -new -key "${FILENAME_BASE}.key" -out "${FILENAME_BASE}.csr" \
-  -subj "/C=US/ST=Massachusetts/L=Boston/O=Department of Innovation and Technology/OU=Digital/CN=$WORKSPACE"
+  -subj "/C=US/ST=Massachusetts/L=Boston/O=Department of Innovation and Technology/OU=Digital/CN=${WORKSPACE:-default}"
 openssl x509 -req -days 365 -in "${FILENAME_BASE}.csr" -signkey "${FILENAME_BASE}.key" -out "${FILENAME_BASE}.crt"
 rm "${FILENAME_BASE}.csr"

--- a/scripts/service-entrypoint.sh
+++ b/scripts/service-entrypoint.sh
@@ -11,7 +11,16 @@ if [ -z "$AWS_S3_CONFIG_URL" ]; then
   echo >&2 'error: missing AWS_S3_CONFIG_URL environment variable'
 else
   aws s3 sync $AWS_S3_CONFIG_URL .
+  if [ -z "$DEPLOY_VARIANT" ]; then
+    echo >&2 'DEPLOY_VARIANT not set'
+  else
+    echo >&2 "syncing $AWS_S3_CONFIG_URL/$DEPLOY_VARIANT"
+    aws s3 sync "$AWS_S3_CONFIG_URL/$DEPLOY_VARIANT" .
+  fi
 fi
+
+# Useful for debugging the AWS syncs
+ls
 
 echo "entrypoint.sh: command"
 

--- a/services-js/access-boston/.gitignore
+++ b/services-js/access-boston/.gitignore
@@ -1,3 +1,4 @@
 /saml-metadata.xml
 service-provider.crt
 service-provider.key
+/apps.yaml

--- a/services-js/access-boston/deploy/Dockerfile
+++ b/services-js/access-boston/deploy/Dockerfile
@@ -33,7 +33,6 @@ RUN yarn install --frozen-lockfile --ignore-scripts
 ADD . /app/
 
 RUN /app/scripts/generate-ssl-key.sh /app/services-js/$WORKSPACE
-RUN /app/scripts/generate-ssl-key.sh /app/services-js/$WORKSPACE service-provider
 
 # This does the building of our repo’s packages, which couldn’t happen during
 # the initial install because we didn’t have source. The scope keeps us from

--- a/services-js/access-boston/fixtures/apps.yaml
+++ b/services-js/access-boston/fixtures/apps.yaml
@@ -1,0 +1,26 @@
+categories:
+  - title: For Everyone
+    apps:
+      - title: The Hub
+        url: https://hub.boston.gov
+  - title: Sponsored Accounts
+    apps:
+      - title: Create Sponsored Account
+        url: https://identity-dev.boston.gov/identityiq/createSponsor.jsf
+        groups:
+          - SG_AB_IAM_TEAM
+      - title: Extend Sponsored Account
+        url: https://identity-dev.boston.gov/identityiq/extendSponsor.jsf
+        groups:
+          - SG_AB_IAM_TEAM
+  - title: Blank Category
+    apps:
+      - title: Create Sponsored Account
+        url: https://identity-dev.boston.gov/identityiq/createSponsor.jsf
+        groups:
+          - SG_NOT_A_GROUP
+      - title: Extend Sponsored Account
+        url: https://identity-dev.boston.gov/identityiq/extendSponsor.jsf
+        groups:
+          - SG_NOT_A_GROUP
+

--- a/services-js/access-boston/package.json
+++ b/services-js/access-boston/package.json
@@ -38,6 +38,7 @@
     "hapi": "^17.4.0",
     "hapi-accept-language2": "^2.0.3",
     "hapi-auth-cookie": "^9.0.0",
+    "js-yaml": "^3.12.0",
     "next": "^6.0.0",
     "next-cookies": "^1.0.2",
     "node-cleanup": "^2.1.2",

--- a/services-js/access-boston/src/lib/api.ts
+++ b/services-js/access-boston/src/lib/api.ts
@@ -4,4 +4,13 @@ export interface InfoResponse {
     name: string;
     url: string;
   }>;
+  requestAccessUrl: string;
+  categories: Array<{
+    title: string;
+    apps: Array<{
+      title: string;
+      url: string;
+      description: string;
+    }>;
+  }>;
 }

--- a/services-js/access-boston/src/pages/index.tsx
+++ b/services-js/access-boston/src/pages/index.tsx
@@ -49,13 +49,23 @@ const SIDEBAR_HEADER_STYLE = css({
   textTransform: 'uppercase',
 });
 
+const APP_ROW_STYLE = css({
+  display: 'inline-block',
+  verticalAlign: 'middle',
+});
+
 export default class IndexPage extends React.Component<Props> {
   static async getInitialProps({ req }) {
     return { info: await fetchJson(req, '/info') };
   }
 
   render() {
-    const { employeeId, accountTools } = this.props.info;
+    const {
+      employeeId,
+      accountTools,
+      requestAccessUrl,
+      categories,
+    } = this.props.info;
 
     return (
       <CrumbContext.Consumer>
@@ -81,23 +91,50 @@ export default class IndexPage extends React.Component<Props> {
               <div className="b b-c">
                 <div className="g">
                   <div className="g--8">
-                    <SectionHeader title="App Category" />
+                    {categories.map(({ title, apps }) => (
+                      <div className="m-b500" key={title}>
+                        <SectionHeader title={title} />
+                        <ul className="ul">
+                          {apps.map(({ title, url, description }) => (
+                            <li key={title}>
+                              <a
+                                href={url}
+                                className={`p-a300 ${APP_ROW_STYLE}`}
+                              >
+                                <div className="t--sans tt-u">{title}</div>
+                                <div style={{ color: CHARLES_BLUE }}>
+                                  {description}
+                                </div>
+                              </a>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ))}
                   </div>
 
-                  <div
-                    className="g--4 p-a200"
-                    style={{ backgroundColor: GRAY_000 }}
-                  >
-                    <h2 className={`${SIDEBAR_HEADER_STYLE} m-b200`}>
-                      Account Tools
-                    </h2>
-                    <ul className="ul">
-                      {accountTools.map(({ name, url }) => (
-                        <li key={name}>
-                          <a href={url}>{name}</a>
-                        </li>
-                      ))}
-                    </ul>
+                  <div className="g--4">
+                    <div
+                      className="p-a200"
+                      style={{ backgroundColor: GRAY_000 }}
+                    >
+                      <h2 className={`${SIDEBAR_HEADER_STYLE} m-b200`}>
+                        Account Tools
+                      </h2>
+                      <ul className="ul">
+                        {accountTools.map(({ name, url }) => (
+                          <li key={name}>
+                            <a href={url}>{name}</a>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+
+                    <div className="t--subinfo p-a200 m-v300">
+                      Is there an app that you need access to that’s not shown
+                      here? Fill out the{' '}
+                      <a href={requestAccessUrl}>request access form</a>.
+                    </div>
                   </div>
                 </div>
               </div>

--- a/services-js/access-boston/src/server/AppsRegistry.test.ts
+++ b/services-js/access-boston/src/server/AppsRegistry.test.ts
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+
+import AppsRegistry from './AppsRegistry';
+
+describe('appsForUserTypeAndGroups', () => {
+  let appsRegistry: AppsRegistry;
+
+  beforeEach(() => {
+    const yamlFixture = yaml.safeLoad(
+      fs.readFileSync(
+        path.resolve(__dirname, '../../fixtures/apps.yaml'),
+        'utf-8'
+      )
+    );
+
+    appsRegistry = new AppsRegistry(yamlFixture);
+  });
+
+  it('returns just the "everyone" category for no groups', () => {
+    expect(appsRegistry.appsForGroups([])).toMatchSnapshot();
+  });
+
+  it('returns apps for a group', () => {
+    // This checks that categories with no apps are not returned
+    expect(appsRegistry.appsForGroups(['SG_AB_IAM_TEAM'])).toMatchSnapshot();
+  });
+});

--- a/services-js/access-boston/src/server/AppsRegistry.ts
+++ b/services-js/access-boston/src/server/AppsRegistry.ts
@@ -1,0 +1,94 @@
+import fs from 'fs';
+import yaml from 'js-yaml';
+
+export interface AppsCategory {
+  title: string;
+  apps: App[];
+}
+
+export interface App {
+  title: string;
+  url: string;
+  description: string;
+  // null groups means "everyone can see this"
+  groups: string[] | null;
+}
+
+export default class AppsRegistry {
+  allCategories: AppsCategory[];
+
+  constructor(appsYaml: any) {
+    const yamlCategories = appsYaml.categories;
+
+    if (!yamlCategories || !Array.isArray(yamlCategories)) {
+      throw new Error('Missing categories array');
+    }
+
+    this.allCategories = yamlCategories.map(c => {
+      const { title, apps: yamlApps } = c;
+
+      if (!title || typeof title !== 'string') {
+        throw new Error('Category missing title: ' + JSON.stringify(c));
+      }
+
+      if (!yamlApps || !Array.isArray(yamlApps)) {
+        throw new Error('Category missing apps array: ' + JSON.stringify(c));
+      }
+
+      const apps: App[] = yamlApps.map(a => {
+        const { title, url, groups, description } = a;
+
+        if (!title || typeof title !== 'string') {
+          throw new Error('App missing a title: ' + JSON.stringify(a));
+        }
+
+        if (!url || typeof url !== 'string') {
+          throw new Error('App missing a url: ' + JSON.stringify(a));
+        }
+
+        if (groups && !Array.isArray(groups)) {
+          throw new Error('groups is not an array: ' + JSON.stringify(a));
+        }
+
+        return {
+          title,
+          url,
+          description: description || '',
+          groups: groups || null,
+        };
+      });
+
+      return { title, apps };
+    });
+  }
+
+  appsForGroups(userGroups: string[]): AppsCategory[] {
+    return (
+      this.allCategories
+        .map(c => ({
+          ...c,
+          apps: c.apps.filter(
+            ({ groups }) =>
+              !groups || !!groups.find(g => userGroups.includes(g))
+          ),
+        }))
+        // Filter out apps with no categories
+        .filter(c => c.apps.length > 0)
+    );
+  }
+}
+
+export async function makeAppsRegistry(yamlPath: string) {
+  const yamlString = await new Promise<string>((resolve, reject) => {
+    fs.readFile(yamlPath, 'utf-8', (err, contents: string) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(contents);
+      }
+    });
+  });
+
+  const appsYaml = yaml.safeLoad(yamlString, { filename: yamlPath });
+  return new AppsRegistry(appsYaml);
+}

--- a/services-js/access-boston/src/server/SamlAuth.test.ts
+++ b/services-js/access-boston/src/server/SamlAuth.test.ts
@@ -1,4 +1,4 @@
-import { makeIdentityProvider } from './SamlAuth';
+import { makeIdentityProvider, parseGroupsAttribute } from './SamlAuth';
 import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
@@ -24,5 +24,21 @@ describe('makeIdentityProvider', () => {
     // We use publicEncrypt just to test that the certificate is parsable.
     const out = crypto.publicEncrypt(certificate, new Buffer('TEST TEXT'));
     expect(out.toString('base64').length).toBeGreaterThan(1);
+  });
+});
+
+describe('parseGroupsAttribute', () => {
+  it('parses out group names', () => {
+    const groupsAttribute = [
+      'cn=COB-Group-TestGrp01,cn=Groups,dc=boston,dc=cob',
+      'cn=SG_AB_IAM_TEAM,cn=Groups,dc=boston,dc=cob',
+      'cn=SG_AB_SERVICEDESK_USERS,cn=Groups,dc=boston,dc=cob',
+    ];
+
+    expect(parseGroupsAttribute(groupsAttribute)).toEqual([
+      'COB-Group-TestGrp01',
+      'SG_AB_IAM_TEAM',
+      'SG_AB_SERVICEDESK_USERS',
+    ]);
   });
 });

--- a/services-js/access-boston/src/server/SamlAuthFake.ts
+++ b/services-js/access-boston/src/server/SamlAuthFake.ts
@@ -24,6 +24,11 @@ export default class SamlAuthFake implements Required<SamlAuth> {
       type: 'login',
       nameId: 'CON01234',
       sessionIndex: 'session',
+      groups: [
+        'COB-Group-TestGrp01',
+        'SG_AB_IAM_TEAM',
+        'SG_AB_SERVICEDESK_USERS',
+      ],
     };
     return Promise.resolve(result);
   }

--- a/services-js/access-boston/src/server/__snapshots__/AppsRegistry.test.ts.snap
+++ b/services-js/access-boston/src/server/__snapshots__/AppsRegistry.test.ts.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`appsForUserTypeAndGroups returns apps for a group 1`] = `
+Array [
+  Object {
+    "apps": Array [
+      Object {
+        "description": "",
+        "groups": null,
+        "title": "The Hub",
+        "url": "https://hub.boston.gov",
+      },
+    ],
+    "title": "For Everyone",
+  },
+  Object {
+    "apps": Array [
+      Object {
+        "description": "",
+        "groups": Array [
+          "SG_AB_IAM_TEAM",
+        ],
+        "title": "Create Sponsored Account",
+        "url": "https://identity-dev.boston.gov/identityiq/createSponsor.jsf",
+      },
+      Object {
+        "description": "",
+        "groups": Array [
+          "SG_AB_IAM_TEAM",
+        ],
+        "title": "Extend Sponsored Account",
+        "url": "https://identity-dev.boston.gov/identityiq/extendSponsor.jsf",
+      },
+    ],
+    "title": "Sponsored Accounts",
+  },
+]
+`;
+
+exports[`appsForUserTypeAndGroups returns just the "everyone" category for no groups 1`] = `
+Array [
+  Object {
+    "apps": Array [
+      Object {
+        "description": "",
+        "groups": null,
+        "title": "The Hub",
+        "url": "https://hub.boston.gov",
+      },
+    ],
+    "title": "For Everyone",
+  },
+]
+`;

--- a/services-js/access-boston/src/server/api.ts
+++ b/services-js/access-boston/src/server/api.ts
@@ -1,17 +1,23 @@
 import { InfoResponse } from '../lib/api';
+import AppsRegistry from './AppsRegistry';
 
 export interface Session {
   nameId: string;
   sessionIndex: string;
+  groups: string[];
 }
 
-export async function infoForUser(session: Session): Promise<InfoResponse> {
+export async function infoForUser(
+  appsRegistry: AppsRegistry,
+  session: Session
+): Promise<InfoResponse> {
   const identityIqUrl =
     process.env.IDENTITY_IQ_URL ||
     'https://identity-dev.boston.gov/identityiq/';
 
   return {
     employeeId: session.nameId,
+    requestAccessUrl: '#',
     accountTools: [
       {
         name: 'Change password',
@@ -22,5 +28,7 @@ export async function infoForUser(session: Session): Promise<InfoResponse> {
         url: `#`,
       },
     ],
+
+    categories: appsRegistry.appsForGroups(session.groups),
   };
 }

--- a/services-js/access-boston/src/stories/IndexPage.stories.tsx
+++ b/services-js/access-boston/src/stories/IndexPage.stories.tsx
@@ -6,6 +6,7 @@ import { InfoResponse } from '../lib/api';
 
 const INFO: InfoResponse = {
   employeeId: 'CON01234',
+  requestAccessUrl: '#',
   accountTools: [
     {
       name: 'Change password',
@@ -14,6 +15,54 @@ const INFO: InfoResponse = {
     {
       name: 'Manage device',
       url: '#',
+    },
+  ],
+  categories: [
+    {
+      title: 'Employee Tools',
+      apps: [
+        {
+          title: 'The Hub',
+          url: '#',
+          description:
+            'Employee directory and other information for employees.',
+        },
+        {
+          title: 'Building Maintenance Form',
+          url: '#',
+          description: 'Report a maintenance problem with a City building.',
+        },
+        {
+          title: 'ESS',
+          url: '#',
+          description: '',
+        },
+        {
+          title: 'Employee Connect',
+          url: '#',
+          description: '',
+        },
+        {
+          title: 'My Learning Plan',
+          url: '#',
+          description: '',
+        },
+      ],
+    },
+    {
+      title: 'Financial Software',
+      apps: [
+        {
+          title: 'BAIS FN',
+          url: '#',
+          description: '',
+        },
+        {
+          title: 'BAIS HCM',
+          url: '#',
+          description: '',
+        },
+      ],
     },
   ],
 };

--- a/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
+++ b/services-js/access-boston/src/stories/__snapshots__/Storyshots.test.ts.snap
@@ -52,46 +52,234 @@ Array [
           className="g--8"
         >
           <div
-            className="sh"
+            className="m-b500"
           >
-            <h2
-              className="sh-title"
+            <div
+              className="sh"
             >
-              App Category
-            </h2>
+              <h2
+                className="sh-title"
+              >
+                Employee Tools
+              </h2>
+            </div>
+            <ul
+              className="ul"
+            >
+              <li>
+                <a
+                  className="p-a300 css-v7ibj3"
+                  href="#"
+                >
+                  <div
+                    className="t--sans tt-u"
+                  >
+                    The Hub
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "#091f2f",
+                      }
+                    }
+                  >
+                    Employee directory and other information for employees.
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="p-a300 css-v7ibj3"
+                  href="#"
+                >
+                  <div
+                    className="t--sans tt-u"
+                  >
+                    Building Maintenance Form
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "#091f2f",
+                      }
+                    }
+                  >
+                    Report a maintenance problem with a City building.
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="p-a300 css-v7ibj3"
+                  href="#"
+                >
+                  <div
+                    className="t--sans tt-u"
+                  >
+                    ESS
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "#091f2f",
+                      }
+                    }
+                  >
+                    
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="p-a300 css-v7ibj3"
+                  href="#"
+                >
+                  <div
+                    className="t--sans tt-u"
+                  >
+                    Employee Connect
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "#091f2f",
+                      }
+                    }
+                  >
+                    
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="p-a300 css-v7ibj3"
+                  href="#"
+                >
+                  <div
+                    className="t--sans tt-u"
+                  >
+                    My Learning Plan
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "#091f2f",
+                      }
+                    }
+                  >
+                    
+                  </div>
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div
+            className="m-b500"
+          >
+            <div
+              className="sh"
+            >
+              <h2
+                className="sh-title"
+              >
+                Financial Software
+              </h2>
+            </div>
+            <ul
+              className="ul"
+            >
+              <li>
+                <a
+                  className="p-a300 css-v7ibj3"
+                  href="#"
+                >
+                  <div
+                    className="t--sans tt-u"
+                  >
+                    BAIS FN
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "#091f2f",
+                      }
+                    }
+                  >
+                    
+                  </div>
+                </a>
+              </li>
+              <li>
+                <a
+                  className="p-a300 css-v7ibj3"
+                  href="#"
+                >
+                  <div
+                    className="t--sans tt-u"
+                  >
+                    BAIS HCM
+                  </div>
+                  <div
+                    style={
+                      Object {
+                        "color": "#091f2f",
+                      }
+                    }
+                  >
+                    
+                  </div>
+                </a>
+              </li>
+            </ul>
           </div>
         </div>
         <div
-          className="g--4 p-a200"
-          style={
-            Object {
-              "backgroundColor": "#f3f3f3",
-            }
-          }
+          className="g--4"
         >
-          <h2
-            className="css-xizy1b m-b200"
+          <div
+            className="p-a200"
+            style={
+              Object {
+                "backgroundColor": "#f3f3f3",
+              }
+            }
           >
-            Account Tools
-          </h2>
-          <ul
-            className="ul"
+            <h2
+              className="css-xizy1b m-b200"
+            >
+              Account Tools
+            </h2>
+            <ul
+              className="ul"
+            >
+              <li>
+                <a
+                  href="#"
+                >
+                  Change password
+                </a>
+              </li>
+              <li>
+                <a
+                  href="#"
+                >
+                  Manage device
+                </a>
+              </li>
+            </ul>
+          </div>
+          <div
+            className="t--subinfo p-a200 m-v300"
           >
-            <li>
-              <a
-                href="#"
-              >
-                Change password
-              </a>
-            </li>
-            <li>
-              <a
-                href="#"
-              >
-                Manage device
-              </a>
-            </li>
-          </ul>
+            Is there an app that you need access to that’s not shown here? Fill out the
+             
+            <a
+              href="#"
+            >
+              request access form
+            </a>
+            .
+          </div>
         </div>
       </div>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7978,6 +7978,13 @@ js-yaml@^3.10.0, js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.8.1, js-yaml@^3.9.0,
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@^3.12.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@~3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"


### PR DESCRIPTION
Apps pulled in from YAML file.

Also:
 - Adds S3 syncing of "variant" directories if they exist, to allow for
   different configs for different variants.
 - No longer generates fresh service key for each deploy, in case they
   actually do need to be consistent.
 - Fixes key / cert arguments being transposed.